### PR TITLE
Only apply insertTr when a match has been found

### DIFF
--- a/.yarn/versions/d35508d3.yml
+++ b/.yarn/versions/d35508d3.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-inputrules": patch

--- a/src/inputrules.ts
+++ b/src/inputrules.ts
@@ -157,8 +157,8 @@ function run(
   const mappedFrom = insertTr.mapping.map(from);
   const mappedTo = insertTr.mapping.map(to);
 
-  let state = view.state.apply(insertTr),
-    $from = state.doc.resolve(mappedFrom);
+  let state: EditorState | null = null,
+    $from = insertTr.doc.resolve(mappedFrom);
 
   let textBefore = $from.parent.textBetween(
     Math.max(0, $from.parentOffset - MAX_MATCH),
@@ -178,11 +178,11 @@ function run(
     }
 
     let match = rule.match.exec(textBefore);
+    if (!match || match[0].length < text.length) continue;
 
-    let tr =
-      match &&
-      match[0].length >= text.length &&
-      rule.handler(state, match, mappedFrom - match[0].length, mappedTo);
+    state ??= view.state.apply(insertTr);
+
+    let tr = rule.handler(state, match, mappedFrom - match[0].length, mappedTo);
 
     if (!tr) continue;
 


### PR DESCRIPTION
Partially addresses #2.

I don't think we can do any better than this, because the rule handler needs to take an EditorState as an argument and produce a Transaction based on that EditorState, so we have to apply the input transaction before calling the rule handler.

But this is still a considerable mitigation, and should mean that the transaction is not applied in most basic editing scenarios. The transaction will still be applied and discarded if the rule relies on imperative checks in the handler to reject the match.